### PR TITLE
change unifi external dns policy to upsert-only

### DIFF
--- a/clusters/talos-robbinsdale/apps/dns/external-dns.yaml
+++ b/clusters/talos-robbinsdale/apps/dns/external-dns.yaml
@@ -185,7 +185,7 @@ spec:
             - --interval=1m
             - --source=ingress
             - --source=service
-            - --policy=sync
+            - --policy=upsert-only
             - --registry=txt
             - --txt-owner-id=default
             - --txt-prefix=k8s.


### PR DESCRIPTION
Hoping it cleans this up:
![image](https://github.com/user-attachments/assets/73870bea-9b00-4231-a44d-95dd45589c17)

Also ideally external DNS system should not be allowed to delete records.